### PR TITLE
addition of Workflow.to_script

### DIFF
--- a/qiime/sdk/job.py
+++ b/qiime/sdk/job.py
@@ -9,9 +9,9 @@
 
 # TODO figure out what the public API should be. For now it's a simple struct.
 class Job:
-    def __init__(self, markdown, uuid, input_artifact_filepaths,
+    def __init__(self, code, uuid, input_artifact_filepaths,
                  parameter_references, output_artifact_filepaths):
-        self.markdown = markdown
+        self.code = code
         self._uuid = uuid
         self.input_artifact_filepaths = input_artifact_filepaths
         self.parameter_references = parameter_references

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
     name='qiime',
     version='2.0.1.dev0',
     packages=find_packages(),
-    install_requires=['python-frontmatter', 'pyyaml']
+    install_requires=['python-frontmatter', 'pyyaml', 'ipymd >= 0.1.2',
+                      'jupyter']
 )


### PR DESCRIPTION
- [x] the job content goes to "markdown" but for a job that's probably not the appropriate name. where should a script go? what about a function? should it be something like ``Job.executable`` which is provided to an execution context. Or maybe we always want the markdown, since it is nicely annotated... 
- [x] ``Workflow.to_markdown`` is pretty general - I can reuse that here if we rename it and then pass a formatter in (currently I modified it to default to using Workflow._to_markdown, and then I pass ``_format_script``, but we probably want a more general function that contains the current functionality and then have ``Workflow.to_markdown`` and ``Workflow.to_script`` call that and pass a formatter)

- [x] markdown (``Workflow.template``) to Python conversion

- [x] handle ipython magic

This can be tested as follows from ``q2d3/demo/analysis-dir``.

```python
In [1]: from qiime.sdk import Workflow

In [2]: w = Workflow.from_markdown('/Users/caporaso/code/diversity/diversity/workflows/feature_table_to_pcoa.md')

In [5]: jpy = w.to_script({'feature_table': 'table.qtf', 'phylogeny': 'phylogeny.qtf'}, {'metric': 'unweighted_unifrac', 'depth': '50'}, {'distance_matrix': 'uu-dm.qtf', 'pcoa_results': 'uu-pc.qtf'})

In [7]: open('./test.py', 'w').write(jpy.markdown)
```

Then, exit ipython and:

```bash
$ python test.py
```