### PR TITLE
stubs ExecutionContext and adds LocalSubprocessExecution

### DIFF
--- a/qiime/sdk/execution.py
+++ b/qiime/sdk/execution.py
@@ -1,0 +1,46 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016--, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import tempfile
+import shutil
+import subprocess
+from concurrent.futures import ProcessPoolExecutor
+
+
+class SubprocessExecutor:
+
+    _python_executable = "python"
+
+    def __call__(self, workflow, input_artifact_filepaths,
+                 parameter_references, output_artifact_filepaths):
+        input_artifact_abs_filepaths = \
+            {k: os.path.abspath(v)
+             for k, v in input_artifact_filepaths.items()}
+        output_artifact_abs_filepaths = \
+            {k: os.path.abspath(v)
+             for k, v in output_artifact_filepaths.items()}
+        job = workflow.to_script(input_artifact_abs_filepaths,
+                                 parameter_references,
+                                 output_artifact_abs_filepaths)
+        temp_dir = tempfile.mkdtemp()
+        pool = ProcessPoolExecutor(max_workers=1)
+        py_filename = os.path.join(temp_dir, 'job.py')
+        with open(py_filename, 'w') as py_file:
+            py_file.write(job.code)
+        # TODO: handle subproccess exceptions
+        future = pool.submit(subprocess.run,
+                             [self._python_executable, py_filename],
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        # TODO: handle callback exceptions
+        # TODO: make sure that tempdir is cleaned up even if there is an
+        # exception in pool.submit or the callback
+        future.add_done_callback(lambda _: shutil.rmtree(temp_dir))
+
+        return future


### PR DESCRIPTION
fixes #35.

From ``q2d3/demo/analysis-dir`` this can be tested as follows:

```python
from qiime.sdk.execution import SubprocessExecutor
from qiime.sdk import Workflow

w = Workflow.from_markdown('/Users/caporaso/code/diversity/diversity/workflows/feature_table_to_pcoa.md')

e = SubprocessExecutor()
f = e(w, {'feature_table': 'table.qtf', 'phylogeny': 'phylogeny.qtf'}, {'metric': 'unweighted_unifrac', 'depth': '50'}, {'distance_matrix': 'uu-dm.qtf', 'pcoa_results': 'uu-pc.qtf'})
print(f.done())
f.result() # When f.done() == True, this will be a subprocess.CompleteProcess
```